### PR TITLE
Fix metadata for SLES15SP3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @Cray-HPE/metal
+*       @Cray-HPE/management-network

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,6 @@
-@Library('csm-shared-library') _
+@Library('csm-shared-library@main') _
 
+def pythonVersion = '3.10'
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME == 'main' ? true : false
 pipeline {
   agent {
@@ -8,6 +9,8 @@ pipeline {
 
   options {
     buildDiscarder(logRotator(numToKeepStr: "10"))
+    disableConcurrentBuilds()
+    timeout(time: 20, unit: 'MINUTES')
     timestamps()
   }
 
@@ -19,12 +22,27 @@ pipeline {
 
   stages {
     stage('Prepare') {
+      agent {
+        docker {
+          image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:${pythonVersion}"
+          reuseNode true
+          args "-v ${env.WORKSPACE}:/workspace"
+        }
+      }
       steps {
+        runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
         sh "make prepare"
       }
     }
 
     stage('Build: RPM') {
+      agent {
+        docker {
+          image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:${pythonVersion}"
+          reuseNode true
+          args "-v ${env.WORKSPACE}:/workspace"
+        }
+      }
       steps {
         sh "make rpm"
       }
@@ -33,8 +51,10 @@ pipeline {
     stage('Publish') {
       steps {
         script {
-          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", arch: "noarch", isStable: isStable)
-          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "sle-15sp2", arch: "noarch", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "sle-15sp3", arch: "noarch", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp2", arch: "src", isStable: isStable)
+          publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "sle-15sp3", arch: "src", isStable: isStable)
         }
       }
     }


### PR DESCRIPTION
Right now metal-net-scripts is missing git information from its description, as well as a value for its distribution.

```
Name        : metal-net-scripts
Version     : 0.0.2
Release     : 1
Architecture: noarch
Install Date: Tue 10 May 2022 07:52:15 PM UTC
Group       : Unspecified
Size        : 28040
License     : HPE Proprietary
Signature   : RSA/SHA256, Tue 16 Nov 2021 08:54:22 PM UTC, Key ID d4dae1e39da39f44
Source RPM  : metal-net-scripts-0.0.2-1.src.rpm
Build Date  : Tue 16 Nov 2021 08:52:02 PM UTC
Build Host  : csm-jenkins-metal-builder-wndekq.us-central1-a.c.cloudbees-202004.internal
Relocations : (not relocatable)
Vendor      : Hewlett Packard Enterprise Development LP
Summary     : Installs Python scripts for network configuration and trouble-shooting
Description :

Distribution: (none)
```

This amends the description with git information while also setting a value for the distribution:
```
Description :
Git Repository: metal-net-scripts
Git Branch: metadata
Git Commit Revision: 8effac94
Git Commit Timestamp: Wed Jun 1 15:31:55 2022 -0400
Distribution: SUSE Linux Enterprise Server 15 SP3
```